### PR TITLE
Add basic life insurance page with its style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Footer from "./components/Footer";
 import HomePage from "./views/HomePage";
 import DeviceInsurancePage from "./views/DeviceInsurancePage";
 import MalariaInsurancePage from "./views/MalariaInsurancePage";
+import LifeInsurancePage from "./views/LifeInsurancePage";
 
 const App = () => {
   return (
@@ -14,6 +15,7 @@ const App = () => {
         <Route path="/" exact component={HomePage} />
         <Route path="/device" component={DeviceInsurancePage} />
         <Route path="/malaria" component={MalariaInsurancePage} />
+        <Route path="/basic-life" component={LifeInsurancePage} />
       </Switch>
       <Footer />
     </Router>

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -10,6 +10,4 @@ test("renders default header elements", () => {
     </Router>
   );
   expect(getByText("Toga")).toBeInTheDocument();
-  expect(getByText("Claims")).toBeInTheDocument();
-  expect(getByText("Request Service")).toBeInTheDocument();
 });

--- a/src/components/Nav/StyledNav.js
+++ b/src/components/Nav/StyledNav.js
@@ -18,7 +18,7 @@ const StyledNav = Styled.nav`
     display: none;
   }
   @media only screen and (max-width: 756px) {
-    width: 50%;
+    width: 60%;
     padding: 10px;
     min-height: 100%;
     .mobile-only{

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -21,7 +21,9 @@ const Nav = ({ onClick, open }) => {
           <Link to="/malaria">Malaria Insurance</Link>
         </li>
         <hr />
-        <li>Basic Life Insurance</li>
+        <li>
+          <Link to="/basic-life">Basic Life Insurance</Link>
+        </li>
         <hr />
         <li>Refer a friend</li>
         <hr />

--- a/src/views/DeviceInsurancePage/index.js
+++ b/src/views/DeviceInsurancePage/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import StyledDevicePage from "./Style";
-import { Link } from "react-router-dom";
 import { PaymentPlanStyle, StyledQuestionSection } from "../commonStyle";
 
 const DeviceInsurance = () => {
@@ -171,7 +170,7 @@ const DeviceInsurance = () => {
               waiting period, no shenanigans.
             </p>
             <p>Simply get answers from the mostly asked questions.</p>
-            <Link className="btn2">Get Started</Link>
+            <a className="btn2">Get Started</a>
           </div>
           <img
             src="https://res.cloudinary.com/toga-insure/image/upload/v1592922060/CommingSoonPage/questionsimg_xnhh7i.png"

--- a/src/views/LifeInsurancePage/Style.js
+++ b/src/views/LifeInsurancePage/Style.js
@@ -1,0 +1,49 @@
+import Styled from "styled-components";
+
+const LifeInsuranceStyle = Styled.div`
+  width: 100%;
+  margin: 70px 0;
+  @media only screen and (max-width: 756px) {
+    font-size: 12px;
+    margin: 30px 0;
+  }
+  font-size: 18px;
+  .top-section{
+    width: 50%;
+    margin: 20px auto;
+    text-align: center;
+    line-height: 32px;
+    @media only screen and (max-width: 756px) {
+      width: 90%;
+      font-size: 12px;
+    }
+    img {
+      width: 60%;
+      @media only screen and (max-width: 756px) {
+        width: 60%;
+      }
+    }
+    h2 {
+      font-size: 36px;
+      letter-spacing: 0.15em;
+      @media only screen and (max-width: 756px) {
+        font-size: 24px;
+      }
+    }
+    .all-caps {
+      text-transform: uppercase;
+    }
+  }
+  .benefit-info {
+    width: 90%;
+    margin: 70px auto;
+    h2 {
+      margin: 10px 0;
+    }
+    .title {
+      color: #6b1587;
+    }
+  }
+`;
+
+export default LifeInsuranceStyle;

--- a/src/views/LifeInsurancePage/index.js
+++ b/src/views/LifeInsurancePage/index.js
@@ -1,0 +1,96 @@
+import React from "react";
+import LifeInsuranceStyle from "./Style";
+import { PaymentPlanStyle, StyledQuestionSection } from "../commonStyle";
+
+const LifeInsurancePage = () => {
+  return (
+    <LifeInsuranceStyle>
+      <section className="top-section">
+        <h2>Basic Life Insurance</h2>
+        <img
+          src="https://res.cloudinary.com/toga-insure/image/upload/v1592308720/CommingSoonPage/cardimg4_oxvwnd.png"
+          alt="Life Insurance"
+        />
+        <p className="all-caps">Protecting the present and the future</p>
+        <p>
+          Toga basic life insurance, offers benefits of protection against
+          personal accident, permanent disability and life that the user might
+          sustain. This plan offers hospitalization payment for the user and
+          compensation payments to the beneficiary of the insured user.
+        </p>
+      </section>
+      <section className="benefit-info">
+        <h3>It works in such ways as:</h3>
+        <div>
+          <p>
+            <strong className="title">Personal Accident</strong> - in which a
+            sum is paid for medical expense as a result of an accident.
+          </p>
+          <p>
+            <strong className="title">Permanent Disability</strong> - provide
+            protection to users who become disabled as a result can no longer
+            work.
+          </p>
+          <p>
+            <strong className="title">Life Cover</strong> - A fee is paid to the
+            beneficiary of the policyholder as a result of the death of the
+            holder.
+          </p>
+        </div>
+      </section>
+      <PaymentPlanStyle>
+        <h2>Payment Plans</h2>
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Monthly</th>
+              <th>Yearly</th>
+              <th>Benefits (what the plan offers)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Plan 1</td>
+              <td>200</td>
+              <td>1,000</td>
+              <td>10,000 (hospitalization) / 100,000 (life)</td>
+            </tr>
+            <tr>
+              <td>Plan 2</td>
+              <td>300</td>
+              <td>2,000</td>
+              <td>20,000 (hospitalization) / 200,000 (life)</td>
+            </tr>
+            <tr>
+              <td>Plan 3</td>
+              <td>500</td>
+              <td>5,000</td>
+              <td>50,000 (hospitalization) / 500,000 (life)</td>
+            </tr>
+          </tbody>
+        </table>
+      </PaymentPlanStyle>
+      <StyledQuestionSection className="questions">
+        <h2>Some Questions & Answers</h2>
+        <div className="content-container">
+          <div>
+            <h3>We understand, you’re busy.</h3>
+            <p>
+              We’ll cover you instantly once your payment is complete. No
+              waiting period, no shenanigans.
+            </p>
+            <p>Simply get answers from the mostly asked questions.</p>
+            <a className="btn2">Get Started</a>
+          </div>
+          <img
+            src="https://res.cloudinary.com/toga-insure/image/upload/v1592922060/CommingSoonPage/questionsimg_xnhh7i.png"
+            alt="curious Happy customer"
+          />
+        </div>
+      </StyledQuestionSection>
+    </LifeInsuranceStyle>
+  );
+};
+
+export default LifeInsurancePage;

--- a/src/views/MalariaInsurancePage/index.js
+++ b/src/views/MalariaInsurancePage/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import MalariaStyle from "./Style";
 import { PaymentPlanStyle, StyledQuestionSection } from "../commonStyle";
 
@@ -131,7 +130,7 @@ const MalariaPage = () => {
               waiting period, no shenanigans.
             </p>
             <p>Simply get answers from the mostly asked questions.</p>
-            <Link className="btn2">Get Started</Link>
+            <a className="btn2">Get Started</a>
           </div>
           <img
             src="https://res.cloudinary.com/toga-insure/image/upload/v1592922060/CommingSoonPage/questionsimg_xnhh7i.png"


### PR DESCRIPTION

#### What does this PR do?
Adds life insurance page

#### Description of Task to be completed?
> - Add life insurance page

#### How should this be manually tested?
> - Clone this branch
> - Then run `npm install` and  `npm start' 
> - Open your browser and visit localhost:3000
> - Click on the menu icon in the header and click on the life insurance nav item
> - You would be taken to a page with details of the basic life insurance plan

#### Any background context you want to provide?
NA